### PR TITLE
Update in the likelihood fit

### DIFF
--- a/DMfit/data/dataset.py
+++ b/DMfit/data/dataset.py
@@ -82,6 +82,10 @@ class DataSet():
        
         self.values = list(map(nb_random_poisson, ntotal * np.asarray(model)))
 
+    def asimov(self, ntotal, model):
+        "Makes a Asimov sample"
+       
+        self.values = list(ntotal * np.asarray(model))
 
     def __str__(self):
         lines = []

--- a/DMfit/llh/likelihoods.py
+++ b/DMfit/llh/likelihoods.py
@@ -130,7 +130,16 @@ class LikelihoodRatioTest:
     @property
     def TS(self):
         return 2 * (self.minLlhH0 - self.minLlhH1)
-        
+
+    def TS_llhinterval(self, param_val, parname_fit, parname_fix):
+        self.models['H0'].parameters[parname_fix].value = param_val
+        self.fit("H0")
+        self.fit("H1")
+        if self.models['H1'].parameters[parname_fit].value > param_val:
+            T = 0
+        else:    
+            T = self.TS
+        return T    
             
     def llhH0(self, pars):
         """
@@ -184,8 +193,62 @@ class LikelihoodRatioTest:
     
     
     def upperlimit(self):
+        
         return 0
     
+    def upperlimit_llhinterval(self, parname_fit, parname_fix, conf_level):        
+        #Default C.L.
+        deltaTS = 1.64
+        if conf_level==90:
+            deltaTS = 1.64
+        elif conf_level==95:
+            deltaTS = 2.71
+
+        # First, we try to find a range [param_low, param_up]
+        # that contains the upper limit value
+
+        self.fit('H1')
+        param_up = self.models['H1'].parameters[parname_fit].value
+        dTS = 0
+        nIterations = 0
+
+        while(dTS<deltaTS) and (nIterations<1000):                
+            nIterations += 1            
+            if param_up < 1e-14:
+                param_up = 1e-14
+            param_up=param_up+3.*np.abs(param_up)                        
+            dTS = self.TS_llhinterval(param_up, parname_fit, parname_fix)
+
+        if (dTS<deltaTS):
+            raise RuntimeError('Can not find upper value to perform bisection search due to maximum number of iteration reached')    
+        param_low = param_up/4.
+
+        # enter the bisection search for upperlimit within a tolerance:
+        # note: code below only for increasing function which should be the case for the test statistics as the function of signal fraction.
+
+        # param_tol = 5e-8
+        ts_tol = 0.001
+        nIterations = 0
+        param_mean = (param_up+param_low)/2. 
+        while ( abs(dTS - deltaTS) > ts_tol ) and (nIterations<500):
+            nIterations += 1
+            param_mean = (param_up+param_low)/2.            
+            dTS = self.TS_llhinterval(param_mean, parname_fit, parname_fix)
+            if dTS == deltaTS:
+                return dTS
+            elif dTS < deltaTS:
+                param_low = param_mean
+            else:
+                param_up = param_mean
+
+        if nIterations==500:
+            print('Warning: maximum number of iteration reached in bisection seacch')
+        
+        # print('upper limit: {}'.format(param_mean))
+        # print('TS value at the output upper limit: {}'.format(dTS))
+
+        return param_mean
+
         
     def __str__(self):
         lines = []


### PR DESCRIPTION
I added:
- the options to parse the data without resampling it (Asimov dataset?)
- the upper limit and TS for likelihood interval method
- update in the Minuit initialiser so that it works with latest version of iMinuit v2.21 (Minuit.from_array_func() is removed in new version of iminuit)